### PR TITLE
switch benchmarks to use yarn

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
 package.lock
+yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ typings/
 
 # next.js build output
 .next
+
+yarn.lock

--- a/Dockerfile.buildkit
+++ b/Dockerfile.buildkit
@@ -2,10 +2,6 @@ FROM node:10
 
 WORKDIR /app
 ADD . .
-
-# For some reason, npm with buildkit fails the first time, but
-# works the second time. :shrug:
-# https://stackoverflow.com/questions/15393821/npm-err-cb-never-called
-RUN npm install . || npm install .
+RUN yarn install
 
 ENTRYPOINT exit 0

--- a/Dockerfile.cachedir
+++ b/Dockerfile.cachedir
@@ -4,12 +4,13 @@ FROM ${baseImage} as builder
 
 WORKDIR /app
 ADD . .
-RUN npm install .
+RUN yarn install
 # Done builder
 
 # Start dir-cache
 FROM node:10 as dir-cache
 COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/yarn.lock /app/yarn.lock
 # Done dir-cache
 
 # Start main

--- a/Dockerfile.cachedirbuildkit
+++ b/Dockerfile.cachedirbuildkit
@@ -8,13 +8,14 @@ ADD . .
 # For some reason, npm with buildkit fails the first time, but
 # works the second time. :shrug:
 # https://stackoverflow.com/questions/15393821/npm-err-cb-never-called
-RUN npm install . || npm install .
+RUN yarn install
 
 # Done builder
 
 # Start dir-cache
 FROM node:10 as dir-cache
 COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/yarn.lock /app/yarn.lock
 # Done dir-cache
 
 # Start main

--- a/Dockerfile.cachedircopy
+++ b/Dockerfile.cachedircopy
@@ -2,18 +2,21 @@
 ARG copyImage="node:10"
 FROM ${copyImage} as copier
 RUN mkdir -p /app/node_modules
+RUN touch /app/yarn.lock
 
 FROM node:10 as builder
 
 WORKDIR /app
 COPY --from=copier /app/node_modules /app/node_modules
+COPY --from=copier /app/yarn.lock /app/yarn.lock
 ADD . .
-RUN npm install .
+RUN yarn install
 # Done builder
 
 # Start dir-cache
 FROM node:10 as dir-cache
 COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/yarn.lock /app/yarn.lock
 # Done dir-cache
 
 # Start main

--- a/Dockerfile.cachemount
+++ b/Dockerfile.cachemount
@@ -4,10 +4,6 @@ FROM node:10
 
 WORKDIR /app
 ADD . .
-
-# For some reason, npm with buildkit fails the first time, but
-# works the second time. :shrug:
-# https://stackoverflow.com/questions/15393821/npm-err-cb-never-called
-RUN --mount=type=cache,target=/root/.npm npm install . || npm install .
+RUN --mount=type=cache,target=/root/.cache yarn install
 
 ENTRYPOINT exit 0

--- a/Dockerfile.naive
+++ b/Dockerfile.naive
@@ -2,6 +2,6 @@ FROM node:10
 
 WORKDIR /app
 ADD . .
-RUN npm install .
+RUN yarn install
 
 ENTRYPOINT exit 0

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ profile:
 
 naked:
 	$(call inject-nonce)
-	npm install .
+	yarn install
 
 naive:
 	$(call inject-nonce)
@@ -75,10 +75,14 @@ tailybuild-base:
 tailybuild: tailybuild-base
 	$(call inject-nonce)
 	docker cp package.json tailybuild:/app/package.json
-	docker exec -it tailybuild npm install .
+	docker exec -it tailybuild yarn install
 
 clean:
 	$(call reset-nonce)
 	rm -fR node_modules
 	docker kill tailybuild && docker rm tailybuild || exit 0
 	docker rmi -f $(shell docker image ls --filter=reference=windmill.build/buildbench-js/* -q) || exit 0
+	docker rmi -f windmill.build/buildbench-js/tailybuild-base || exit 0
+	docker rmi -f windmill.build/buildbench-js/cachedir-base || exit 0
+	docker rmi -f windmill.build/buildbench-js/cachedircopy-base || exit 0
+	docker rmi -f windmill.build/buildbench-js/cachedirbuildkit-base || exit 0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Do you run your NodeJS frontend locally in Docker?
 
 We got sick of waiting for 2 minute installs every time the package.json changed.
 
-How can we get NPM to install things incrementally, like it does locally?
+How can we get Yarn to install things incrementally, like it does locally?
 
 ## Usage
 
@@ -21,27 +21,27 @@ to run a set of incremental docker builds with different build-optimization tech
 Each benchmark makes a trivial change to package.json (where "trivial" means that
 we don't change the dependencies).
 
-- Naked: Run `npm install` without containers
-- Naive: Run `npm install` inside Docker
-- Buildkit: Run `npm install` inside Docker with Buildkit enabled
-- Cachemount: Run `npm install` with /root/.cache mounted as a cache directory, with Buildkit's [experimental build-time mounts](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md).
-- Cachedir: Run `npm install`, using /app/node_modules from previous builds as the base of the new build.
-- CachedirCopy: Run `npm install`, copying /app/node_modules from previous builds to the new build.
-- CachedirBuildkit: Run `npm install`, using /app/node_modules from previous builds as the base of the new build, and using Buildkit.
+- Naked: Run `yarn install` without containers
+- Naive: Run `yarn install` inside Docker
+- Buildkit: Run `yarn install` inside Docker with Buildkit enabled
+- Cachemount: Run `yarn install` with /root/.cache mounted as a cache directory, with Buildkit's [experimental build-time mounts](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md).
+- Cachedir: Run `yarn install`, using /app/node_modules from previous builds as the base of the new build.
+- CachedirCopy: Run `yarn install`, copying /app/node_modules from previous builds to the new build.
+- CachedirBuildkit: Run `yarn install`, using /app/node_modules from previous builds as the base of the new build, and using Buildkit.
 
 ## Results
 
 When the builds finish, you should get results that look like this:
 
 ```
-Make naive: 58.278516s
-Make buildkit: 56.46206s
-Make cachemount: 45.003745s
-Make cachedir: 20.155373s
-Make cachedircopy: 22.342685s
-Make cachedirbuildkit: 14.674813s
-Make tailybuild: 14.977888s
-Make naked: 21.306247s
+Make naive: 80.815424s
+Make buildkit: 62.434007s
+Make cachemount: 69.091764s
+Make cachedir: 8.885972s
+Make cachedircopy: 9.508763s
+Make cachedirbuildkit: 3.951881s
+Make tailybuild: 1.607163s
+Make naked: 1.598011s
 ```
 
 Numbers may vary based on hardware, operating system, and Docker version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "@windmilleng/buildbench-js",
-    "nonce": "Tue Nov  6 14:46:19 EST 2018",
+    "name": "buildbench-js",
+    "nonce": "Wed Nov  7 01:22:41 EST 2018",
     "version": "0.0.1",
     "description": "Shared component that contains the Ship Init app",
     "author": "Windmill Engineering",


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/init:

4d593427aafea094af0a32aa752d0d2e3b0dc8fb (2018-11-07 01:26:15 -0500)
switch benchmarks to use yarn

86d3b43affdd82112e93f46d93bc179f2898a716 (2018-11-06 14:52:58 -0500)
benchmarks for different kinds of node_modules caches